### PR TITLE
[Fix] getImageData error on _pixelSample

### DIFF
--- a/src/webrtc/webrtc_recorder.js
+++ b/src/webrtc/webrtc_recorder.js
@@ -311,9 +311,13 @@ Scoped.define("module:WebRTC.RecorderWrapper", [
             },
 
             _pixelSample: function(samples, callback, context) {
+                if (!this._video.videoWidth) {
+                    callback.call(context || this, 0, 0, 0);
+                    return;
+                }
                 samples = samples || 100;
-                var w = this._video.videoWidth || this._video.clientWidth;
-                var h = this._video.videoHeight || this._video.clientHeight;
+                var w = this._video.videoWidth;
+                var h = this._video.videoHeight;
                 var wc = Math.ceil(Math.sqrt(w / h * samples));
                 var hc = Math.ceil(Math.sqrt(h / w * samples));
                 var canvas = document.createElement('canvas');


### PR DESCRIPTION
This happened when the recorder was hidden and _pixelSample was called
before the stream was loaded. Since videoWidth, videoHeight, clientWidth and
clientHeight  were equal to 0 the values being passed to _pixelSample were NaN.

If videoWidth and videoHeight are equal to 0 the pixelSample will always
return (0, 0, 0), even when we have clientWidth and clientHeight.  This
is because the video isn't loaded yet. So it doesn't make sense to get
pixel samples of something that isn't yet loaded.